### PR TITLE
Removing allowBackup attribute.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     package="com.scottyab.rootbeer.sample" >
 
     <application
-        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >


### PR DESCRIPTION
allowBackup attribute shouldn't be used in libraries due to build problems.