### PR TITLE
squid:S1488, squid:S1118 - Local Variables should not be declared and…

### DIFF
--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/Const.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/Const.java
@@ -3,7 +3,11 @@ package com.scottyab.rootbeer;
 /**
  * Created by mat on 19/06/15.
  */
-public class Const {
+public final class Const {
+
+    private Const() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static final String[] knownRootAppsPackages = {
             "com.noshufou.android.su",

--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
@@ -45,10 +45,8 @@ public class RootBeer {
         boolean testSuExists = checkSuExists();
         boolean testRootNative = checkForRootNative();
 
-        boolean result = rootManagement || potentiallyDangerousApps || suBinary
+        return rootManagement || potentiallyDangerousApps || suBinary
                 || busyboxBinary || dangerousProps || rwSystem || testKeys || testSuExists || testRootNative;
-
-        return result;
     }
 
     /**
@@ -330,8 +328,7 @@ public class RootBeer {
 
         RootBeerNative rootBeerNative = new RootBeerNative();
         rootBeerNative.setLogDebugMessages(true);
-        boolean nativeRoot = rootBeerNative.checkForRoot(paths) > 0;
-        return nativeRoot;
+        return rootBeerNative.checkForRoot(paths) > 0;
     }
 
 }

--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/util/QLog.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/util/QLog.java
@@ -118,9 +118,8 @@ public final class QLog {
         int lineNo = elements[depth].getLineNumber();
         int i = callerClassPath.lastIndexOf('.');
         String callerClassName = callerClassPath.substring(i + 1);
-        String trace = callerClassName + ": " + callerMethodName + "() ["
+        return callerClassName + ": " + callerMethodName + "() ["
                 + lineNo + "] - ";
-        return trace;
     }
 
     /**

--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/util/Utils.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/util/Utils.java
@@ -5,8 +5,11 @@ import java.lang.reflect.Method;
 /**
  * Created by scottab on 30/06/15.
  */
-public class Utils {
+public final class Utils {
 
+    private Utils() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
     /**
      * In Development - an idea of ours was to check the if selinux is enforcing - this could be disabled for some rooting apps
      * Checking for selinux mode


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1488 - Local Variables should not be declared and then immediately returned or thrown
squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat