### PR TITLE
Multiple quality improvements

### DIFF
--- a/app/src/main/java/com/scottyab/rootbeer/sample/MainActivity.java
+++ b/app/src/main/java/com/scottyab/rootbeer/sample/MainActivity.java
@@ -98,12 +98,6 @@ public class MainActivity extends ActionBarActivity {
         results.setText(b.toString());
     }
 
-
-    public void checkForRoot(Context context){
-        RootBeer rootBeer = new RootBeer(context);
-
-    }
-
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.

--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
@@ -2,7 +2,6 @@ package com.scottyab.rootbeer;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
-
 import com.scottyab.rootbeer.util.QLog;
 
 import java.io.BufferedReader;
@@ -197,7 +196,7 @@ public class RootBeer {
         return propval.split("\n");
     }
 
-    private String[] mountReader() {
+    private static String[] mountReader() {
         InputStream inputstream = null;
         try {
             inputstream = Runtime.getRuntime().exec("mount").getInputStream();
@@ -256,13 +255,14 @@ public class RootBeer {
         boolean result = false;
 
         String[] lines = propsReader();
+        StringBuilder badValue;
         for (String line : lines) {
-            for (String key : dangerousProps.keySet()) {
-                if (line.contains(key)) {
-                    String badValue = dangerousProps.get(key);
-                    badValue = "[" + badValue + "]";
+            for (Map.Entry<String, String> stringStringEntry : dangerousProps.entrySet()) {
+                if (line.contains(stringStringEntry.getKey())) {
+                    badValue = new StringBuilder(stringStringEntry.getValue());
+                    badValue.append("[").append(badValue).append("]");
                     if (line.contains(badValue)) {
-                        QLog.v(key + " = " + badValue + " detected!");
+                        QLog.v(stringStringEntry.getKey() + " = " + badValue + " detected!");
                         result = true;
                     }
                 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules pmd:UseStringBufferForStringAppends - Use String Buffer For String Appends
squid:S1854 - Dead stores should be removed
squid:S1066 - Collapsible "if" statements should be merged
squid:S2325 - "private" methods that don't access instance data should be "static"
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=pmd:UseStringBufferForStringAppends
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1854
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1066
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat