### PR TITLE
Remove appcompat-v7 dependency

### DIFF
--- a/rootbeerlib/build.gradle
+++ b/rootbeerlib/build.gradle
@@ -28,7 +28,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:appcompat-v7:$supportLibVer"
 }
 
 


### PR DESCRIPTION
Since this library doesn't require this dependency, appcompat-v7 should be removed. Some projects may not use it, and some may have version conflict with their own dependencies. 