### PR TITLE
Bug/ndk unsatisfied link error (fix for RootCloak)

### DIFF
--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
@@ -370,8 +370,14 @@ public class RootBeer {
         }
 
         RootBeerNative rootBeerNative = new RootBeerNative();
-        rootBeerNative.setLogDebugMessages(loggingEnabled);
-        return rootBeerNative.checkForRoot(paths) > 0;
+        try {
+            rootBeerNative.setLogDebugMessages(loggingEnabled);
+            return rootBeerNative.checkForRoot(paths) > 0;
+        } catch (UnsatisfiedLinkError e) {
+            // TODO FIX: at this point - have detectRootCloakingApps() return true,
+            //                           have checkForRootNative() return false
+            return true;
+        }
     }
 
 }


### PR DESCRIPTION
The UnsatisfiedLinkError occurs when RootCloak blocks access to the Native Libraries, even though the native Libraries have been loaded. I have a temporary fix to allow for the app to return root detected from a try catch within the "checkForRootNative()" (without which the application crashes) where I have the method temporarily return true, but further code is necessary to change the return for "detectRootCloakingApps()" to true based on this access limitation.