### PR TITLE
Update Android Gradle plugin to 2.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
@@ -348,13 +348,13 @@ public class RootBeer {
     /**
      * Checks if device has ReadAccess to the Native Library
      * Precondition: canLoadNativeLibrary() ran before this and returned true
-     * @return true if device has Read Access | false if UnsatisfiedLinkError Occurs
      *
      * Description: RootCloak automatically blocks read access to the Native Libraries, however
      * allows for them to be loaded into memory. This check is an indication that RootCloak is
      * installed onto the device.
      *
-     * */
+     * @return true if device has Read Access | false if UnsatisfiedLinkError Occurs
+     */
     public boolean checkForNativeLibraryReadAccess() {
         RootBeerNative rootBeerNative = new RootBeerNative();
         try {

--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/util/QLog.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/util/QLog.java
@@ -29,7 +29,7 @@ public final class QLog {
     }
 
     /**
-     * @param obj
+     * @param obj the object to log
      * @param cause
      *            The exception which caused this error, may not be null
      */
@@ -125,7 +125,7 @@ public final class QLog {
     /**
      * Prints the stack trace to mubaloo log and standard log
      *
-     * @param e
+     * @param e the exception to log
      */
     public static void handleException(final Exception e) {
         QLog.e(e.toString());


### PR DESCRIPTION
Update to the latest Android Gradle plugin `2.3.3`.

This also fixes a Javadoc error (typo `@returm` vs. `@return`) causing a build failure that accidentally got introduced [here](https://github.com/scottyab/rootbeer/pull/49/files#diff-e3584646193961da9c0fc9623683bc63R351).

<sub><sup>Please NO GitHub rebase/squash merges. If you'd like me to combine some or all of the commits, please let me know, and I will update my branch. Thank you.</sup></sub>