### PR TITLE
fixed misspelled javadoc annotation from retrum to retrun

### DIFF
--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
@@ -348,7 +348,7 @@ public class RootBeer {
     /**
      * Checks if device has ReadAccess to the Native Library
      * Precondition: canLoadNativeLibrary() ran before this and returned true
-     * @returm true if device has Read Access | false if UnsatisfiedLinkError Occurs
+     * @return true if device has Read Access | false if UnsatisfiedLinkError Occurs
      *
      * Description: RootCloak automatically blocks read access to the Native Libraries, however
      * allows for them to be loaded into memory. This check is an indication that RootCloak is


### PR DESCRIPTION
Hi,

Thanks for this awesome library! I tried to do a build on master, but was getting this error: 
```
:rootbeerlib:androidJavadocsPicked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Djavax.xml.accessExternalSchema=all
/home/jitpack/build/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java:351: error: unknown tag: returm
     * @returm true if device has Read Access | false if UnsatisfiedLinkError Occurs
       ^
```

I think it was just misspelled javadoc annotation. Let me know if you have any questions!