### PR TITLE
Delete strings.xml

### DIFF
--- a/rootbeerlib/src/main/res/values/strings.xml
+++ b/rootbeerlib/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">RootBeerLib</string>
-</resources>


### PR DESCRIPTION
If I don't override the `app_name` in my Application `strings.xml` but remove it, my App get the name `RootBeerLib`.
This happen because this library brings the resource called `app_name`.

I think that is an issue and the App should not compile in such a case (because in my `AndroidManifest.xml` is use `app_name` while it is not declared somewhere).

if you don't use the string identifier `app_name` somewhere in the library it is safe to remove the file and this commit shouldn't break anything. Expect applications or libraries out there which require a `app_name` but haven't defined it by themself. But again, this is an issue 😁 .