### PR TITLE
Fix checking read-only paths

### DIFF
--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
@@ -221,7 +221,7 @@ public class RootBeer {
 
     private String[] mountReader() {
         try {
-            InputStream inputstream = Runtime.getRuntime().exec("mount").getInputStream();
+            InputStream inputstream = Runtime.getRuntime().exec("cat /proc/mounts").getInputStream();
             if (inputstream == null) return null;
             String propVal = new Scanner(inputstream).useDelimiter("\\A").next();
             return propVal.split("\n");


### PR DESCRIPTION
The `mount` command appears to be returning the output in a different way than the code is expecting.

I've checked three linux devices (Android emulator, MacBookPro, and an Android Device) and they all return the output in the following format (after splitting on spaces, the indexes are):

[0] - The device that is mounted
[1] - The word "on"
[2] - The mount point
[3] - The word "type"
[4] - The file-system type
[5] - The comma separated options enclosed in parenthases

Alternate solution would be to change the indexes we use to 2, 5 (and make sure there are at least 6 args).

Just thought I'd put this up here. I found this while doing my research. The entire `checkForRWPaths` appears to be broken.