### PR TITLE
Fixed the issue where root detection not working for android 14+ Emulators

### DIFF
--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
@@ -264,6 +264,7 @@ public class RootBeer {
         final Map<String, String> dangerousProps = new HashMap<>();
         dangerousProps.put("ro.debuggable", "1");
         dangerousProps.put("ro.secure", "0");
+        dangerousProps.put("ro.adb.secure", "1"); // Added the new property for rooted Emulators
 
         boolean result = false;
 

--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
@@ -264,7 +264,7 @@ public class RootBeer {
         final Map<String, String> dangerousProps = new HashMap<>();
         dangerousProps.put("ro.debuggable", "1");
         dangerousProps.put("ro.secure", "0");
-        dangerousProps.put("ro.adb.secure", "1"); // Added the new property for rooted Emulators
+        dangerousProps.put("ro.adb.secure", "1"); // Added the new property for rooted Emulators from Android 14
 
         boolean result = false;
 


### PR DESCRIPTION
### Issue Summary
Starting with Android 14, emulators no longer provide access to the ro.debuggable and ro.secure properties, as noted in [this issue](https://issuetracker.google.com/issues/298287672). These properties were critical for our root detection logic, and their unavailability has caused our root detection to fail on Android 14+ emulators.

As our team primarily relies on rooted emulators for testing, this issue has disrupted our workflows and impacted testing capabilities.

### Investigation
To address this, I explored alternative properties that could reliably indicate rooted devices. During this process, I came across [this discussion on XDA](https://xdaforums.com/t/ro-debuggable-1-but-rooted-debugging-does-not-show-up.4686059/), which suggested using the ro.adb.secure property. This property appears to be a reliable substitute for detecting rooted devices in Android 14+ environments.

### Proposed Solution
This pull request modifies our root detection logic to include the ro.adb.secure property as an alternative check when ro.debuggable and ro.secure are unavailable. This ensures that our root detection continues to function properly on Android 14+ emulators.

### Benefits

- Restores root detection functionality on Android 14+ emulators.
- Allows the team to continue using rooted emulators for testing purposes.
- Maintains compatibility with older Android versions without impacting existing behavior.

### Request for Review
I kindly request you to review and approve this pull request so that we can resolve the issue and resume testing on rooted emulators seamlessly.

### Developer checklist

- [x] Run the app and tested the new/edited functionality to conform to the expected behaviour
- [ ] Run the following `./gradlew test` and confirmed all tests pass.