### PR TITLE
Enforce 16KB page size for all ABIs

### DIFF
--- a/rootbeerlib/src/main/cpp/CMakeLists.txt
+++ b/rootbeerlib/src/main/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.4.1)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-z,relro -Wl,-z,now")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-z,relro -Wl,-z,now")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-z,relro -Wl,-z,now -Wl,-z,max-page-size=16384")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_library(toolChecker SHARED


### PR DESCRIPTION
Closes #241 

It seems that `ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` will only use 16KB for 64-bit ABIs which is likely all we care, however when running [check_elf_alignment.sh](https://cs.android.com/android/platform/superproject/main/+/main:system/extras/tools/check_elf_alignment.sh) over my app's APK it reports there are unaligned libs (for x86 and armeabi-v7a). Even if not strictly necessary, it would be nice to see the tool report "ELF Verification Successful" and not have to look further.

Inspired by https://github.com/sqlcipher/sqlcipher-android/blob/f3475e86aeecd29f13a3ba7bca971d7753b8bfa4/sqlcipher/src/main/jni/sqlcipher/Android.mk#L39

Output of check_elf_alignment.sh with this repository's app once this change is added:
```
=== ELF alignment ===
/var/folders/_8/0lh25nq123l7wc5xb5_n7s000000gn/T/rootbeer_out_XXXXX.3za2Ap7EU6/lib/armeabi-v7a/libtoolChecker.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_8/0lh25nq123l7wc5xb5_n7s000000gn/T/rootbeer_out_XXXXX.3za2Ap7EU6/lib/x86/libtoolChecker.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_8/0lh25nq123l7wc5xb5_n7s000000gn/T/rootbeer_out_XXXXX.3za2Ap7EU6/lib/arm64-v8a/libtoolChecker.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_8/0lh25nq123l7wc5xb5_n7s000000gn/T/rootbeer_out_XXXXX.3za2Ap7EU6/lib/x86_64/libtoolChecker.so: \e[32mALIGNED\e[0m (2**14)
ELF Verification Successful
=====================
```

Additional context: https://developer.android.com/guide/practices/page-sizes#elf-alignment

### Developer checklist

- [x] Run the app and tested the new/edited functionality to conform to the expected behaviour
- [x] Run the following `./gradlew test` and confirmed all tests pass.