### PR TITLE
Include /system_ext/bin when searching for the su binary.

### DIFF
--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/Const.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/Const.java
@@ -82,6 +82,7 @@ final class Const {
             "/system/sd/xbin/",
             "/system/usr/we-need-root/",
             "/system/xbin/",
+            "/system_ext/bin/",
             "/cache/",
             "/data/",
             "/dev/"


### PR DESCRIPTION
Newer versions of Magisk use this path on Google Pixel devices for example.